### PR TITLE
proxyprovider: Add error handlers

### DIFF
--- a/proxyprovider/clash/type.go
+++ b/proxyprovider/clash/type.go
@@ -111,13 +111,16 @@ func ParseClashConfig(raw []byte) ([]option.Outbound, error) {
 	if config.Proxies == nil || len(config.Proxies) == 0 {
 		return nil, fmt.Errorf("no proxies found in clash config")
 	}
-	m := make([]option.Outbound, 0, len(config.Proxies))
+	var options []option.Outbound
 	for i, proxy := range config.Proxies {
-		options, err := proxy.Proxy.GenerateOptions()
+		opt, err := proxy.Proxy.GenerateOptions()
 		if err != nil {
 			return nil, fmt.Errorf("parse proxy[%d], tag: `%s` failed: %s", i+1, proxy.Proxy.Tag(), err)
 		}
-		m = append(m, *options)
+		options = append(options, *opt)
 	}
-	return m, nil
+	if options == nil || len(options) == 0 {
+		return nil, fmt.Errorf("no outbounds found in clash config")
+	}
+	return options, nil
 }

--- a/proxyprovider/raw/type.go
+++ b/proxyprovider/raw/type.go
@@ -2,6 +2,7 @@ package raw
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 
 	"github.com/sagernet/sing-box/option"
@@ -19,10 +20,15 @@ func ParseRawConfig(raw []byte) ([]option.Outbound, error) {
 	rawStr := string(raw)
 	rawStr = strings.TrimSpace(rawStr)
 	_raw, err := base64.URLEncoding.DecodeString(rawStr)
-	if err == nil {
+	if err != nil {
+		return nil, err
+	} else {
 		rawStr = string(_raw)
 	}
 	rawList := strings.Split(rawStr, "\n")
+	if rawList == nil || len(rawList) == 0 {
+		return nil, fmt.Errorf("no peellists found in raw config")
+	}
 	var peerList []option.Outbound
 	for _, r := range rawList {
 		rs := string(r)
@@ -63,6 +69,9 @@ func ParseRawConfig(raw []byte) ([]option.Outbound, error) {
 			return nil, err
 		}
 		peerList = append(peerList, *peer.Options())
+		if peerList == nil || len(peerList) == 0 {
+			return nil, fmt.Errorf("no outbounds found in raw config")
+		}
 	}
 	return peerList, nil
 }

--- a/proxyprovider/singbox/singbox.go
+++ b/proxyprovider/singbox/singbox.go
@@ -1,6 +1,8 @@
 package singbox
 
 import (
+	"fmt"
+
 	"github.com/sagernet/sing-box/common/json"
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/option"
@@ -16,6 +18,9 @@ func ParseSingboxConfig(raw []byte) ([]option.Outbound, error) {
 	if err != nil {
 		return nil, err
 	}
+	if outboundConfig.Outbounds == nil || len(outboundConfig.Outbounds) == 0 {
+		return nil, fmt.Errorf("no outbounds found in sing-box config")
+	}
 	var options []option.Outbound
 	for _, outboundOptions := range outboundConfig.Outbounds {
 		switch outboundOptions.Type {
@@ -27,6 +32,9 @@ func ParseSingboxConfig(raw []byte) ([]option.Outbound, error) {
 			// removeDetour(&outboundOptions)
 			options = append(options, outboundOptions)
 		}
+	}
+	if options == nil || len(options) == 0 {
+		return nil, fmt.Errorf("no outbounds found in sing-box config")
 	}
 	return options, nil
 }


### PR DESCRIPTION
若遇到 sing-box proxyprovider 后
因为 raw.ParseRawConfig 在 Decode 失败后没有返回 err 而导致 ~~几乎永远~~ 不会进入 singbox.ParseSingboxConfig，
https://github.com/yaotthaha/sing-box-pub/blob/61bde2826536ab660c04d3f4d56240335525f836/proxyprovider/request.go#L45-L50

添加错误处理后不再有这个问题